### PR TITLE
fix(#19) add property "write" to fit morgan streamOptions definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ RotatingFileStream.prototype._write = function(chunk, encoding, callback) {
 	this._rewrite();
 };
 
+RotatingFileStream.prototype.write = RotatingFileStream.prototype._write;
+
 RotatingFileStream.prototype._writev = function(chunks, callback) {
 	chunks[chunks.length - 1].cb = callback;
 	this.chunks = this.chunks.concat(chunks);


### PR DESCRIPTION
a possible fix to solve #19:

the problem is morgan requires a stream which has a `write` property. so a `write` which references to `_write` is added in rfs.