### PR TITLE
Using slightly faster timestamp generator function

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ RotatingFileStream.prototype.move = function(retry) {
 };
 
 RotatingFileStream.prototype.now = function() {
-	return new Date().getTime();
+	return Date.now();
 };
 
 RotatingFileStream.prototype.open = function(retry) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "author": "Daniele Ricci <daniele.icc@gmail.com> (https://github.com/iccicci)",
   "contributors": [
     "cicci",
-    "allevo"
+    "allevo",
+    "Jorge Silva <jorgemsrs@gmail.com>"
   ],
   "license": "MIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION
Not really important but `new Date()` has to perform heap allocation for an entire `Date` instance while `Date.now()` returns a simple `Number`.
Never hit a performance problem with the previous strategy; this commit just aims at marginally improving what is already good without sacrificing readability. Gold plating.

Thanks for the really cool project. Good job!