### PR TITLE
Fix bug -the active log file is not re-created after being manually deleted by the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,16 +96,16 @@ RotatingFileStream.prototype._rewrite = function() {
 };
 
 RotatingFileStream.prototype._write = function(chunk, encoding, callback) {
-  var self = this;
-  // Check if active file still exist
-  // If the file is exist we do nothing else we re-create the file and continue append the logs.
-  fs.access(self.name, FS_F_OK, function (err) {
-    if (err) {
-      self.open()
-    }
-  })
-  this.chunks.push({ chunk: chunk, cb: callback });
-  this._rewrite();
+	var self = this;
+	// Check if active file still exist
+	// If the file is exist we do nothing else we re-create the file and continue append the logs.
+	fs.access(self.name, FS_F_OK, function (err) {
+		if (err) {
+			self.open()
+		}
+	})
+	this.chunks.push({ chunk: chunk, cb: callback });
+	this._rewrite();
 };
 
 RotatingFileStream.prototype._writev = function(chunks, callback) {

--- a/index.js
+++ b/index.js
@@ -100,10 +100,8 @@ RotatingFileStream.prototype._write = function(chunk, encoding, callback) {
 	// Check if active file still exist
 	// If the file is exist we do nothing else we re-create the file and continue append the logs.
 	fs.access(self.name, FS_F_OK, function (err) {
-		if (err) {
-			self.open()
-		}
-	})
+		if (err) self.open();
+	});
 	this.chunks.push({ chunk: chunk, cb: callback });
 	this._rewrite();
 };

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ RotatingFileStream.prototype._write = function(chunk, encoding, callback) {
 	// Check if active file still exist
 	// If the file is exist we do nothing else we re-create the file and continue append the logs.
 	fs.access(self.name, FS_F_OK, function (err) {
-		if (err) self.open();
+		if(err) self.open();
 	});
 	this.chunks.push({ chunk: chunk, cb: callback });
 	this._rewrite();

--- a/index.js
+++ b/index.js
@@ -96,8 +96,16 @@ RotatingFileStream.prototype._rewrite = function() {
 };
 
 RotatingFileStream.prototype._write = function(chunk, encoding, callback) {
-	this.chunks.push({ chunk: chunk, cb: callback });
-	this._rewrite();
+  var self = this;
+  // Check if active file still exist
+  // If the file is exist we do nothing else we re-create the file and continue append the logs.
+  fs.access(self.name, FS_F_OK, function (err) {
+    if (err) {
+      self.open()
+    }
+  })
+  this.chunks.push({ chunk: chunk, cb: callback });
+  this._rewrite();
 };
 
 RotatingFileStream.prototype._writev = function(chunks, callback) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var path = require("path");
 var util = require("util");
 var utils = require("./utils");
 var Writable = require("stream").Writable;
+var FS_F_OK = fs.constants ? fs.constants.F_OK : fs.F_OK;
 
 function RotatingFileStream(filename, options) {
 	if(! (this instanceof RotatingFileStream)) return new RotatingFileStream(filename, options);


### PR DESCRIPTION
The current behavior of the rotating-file-stream(rfs) is that it will create a log file and it will rotate incrementally. The problem occur when the user/client is manually deleted the active log file and it is no longer re-created. This is my proposed solution.