### PR TITLE
Use node timers for interval

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { Readable, Writable } from "stream";
 import { Stats, close, createReadStream, createWriteStream, mkdir, open, readFile, rename, stat, unlink, write, writeFile } from "fs";
 import { parse, sep } from "path";
 import { TextDecoder } from "util";
+import { setTimeout } from "timers";
 
 class RotatingFileStreamError extends Error {
 	public code: string;


### PR DESCRIPTION
## Problem

Not all node environments support setTimeout with unref by default. For example jest env default or electron renderer with node integration by default use timeout from window(without unref).

## Solution

Explicit import timers with unref.