### PR TITLE
Fix the un-handled exceptions like permission issue return from rfs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -161,9 +161,11 @@ export class RotatingFileStream extends Writable {
 
 	private rewrite(chunk: Chunk, callback: Callback): void {
 		const destroy = (error: Error): void => {
-			this.destroy();
-
-			return callback(error);
+			try {
+				this.destroy();
+			} catch(error) {
+				return callback(error);
+			}
 		};
 
 		const rewrite = (): void => {


### PR DESCRIPTION
Hi guys, I just found an issue in which if the log file don't have a write permission. 
The error will occur if the log file is read-only that was modified by an another node app.

It will return an exception like this which is confusing to the end-user:
```
node app.js
Express server listening on port 3333
TypeError: this.destroy is not a function
    at destroy (/home/armano/_node/webinnov_project/node_modules/rotating-file-stream/index.js:71:18)
    at rewrite (/home/armano/_node/webinnov_project/node_modules/rotating-file-stream/index.js:78:24)
    at fsStat (/home/armano/_node/webinnov_project/node_modules/rotating-file-stream/index.js:102:28)
    at FSReqWrap.oncomplete (fs.js:111:15)

```
To solve this TypeError I have modified the destroy() function to put in a try-catch. For example:
```
  private rewrite(chunk: Chunk, callback: Callback): void {
    const destroy = (error: Error): void => {
      try {
        this.destroy();
      } catch(error) {
        return callback(error);
      }
    };
...
...
```
Here's my snippets using the rfs:
```
this._debuggerStream = rfs.createStream("debug.log", {
  size: '50M',
  interval: '1d',
  immutable: true,
  path: this._directory,
  mode: 0o777
})

// Since we have the try-catch, the exception will now catch here instead of displaying
// TypeError: this.destroy is not a function --which is confusing to the end-user
this._debuggerStream.on('error', function (err) {
  console.log('Debug Error - %s', err)
})
```

What do you think of my fix? Or do you have idea on how to catch the rfs exception in onError event? 

Thanks