### PR TITLE
fix(makePath): avoid EEXIST error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -239,6 +239,7 @@ export class RotatingFileStream extends Writable {
 		this.fsMkdir(dir, (error: NodeJS.ErrnoException): void => {
 			if(error) {
 				if(error.code === "ENOENT") return this.makePath(dir, (error: Error): void => (error ? callback(error) : this.makePath(name, callback)));
+				if (error.code === "EEXIST") return callback();
 				return callback(error);
 			}
 


### PR DESCRIPTION
Thanks for the amazing tool. I notice if we create two streams that have the same parent directory that doesn't exist, 'EEXIST' error will come out. For example. if we create two streams, which are `log/access/access.log` and `log/error/error.log`, and `log` directory doesn't exist. Then `log/access/access.log` will try to create `log` directory, and `log/error/error.log` will also try to create `log` directory, which will lead `EEXIST` error. Add a condition check and return `callback()` can avoid this error.