### PR TITLE
Fix occasional crash on interval change

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -200,12 +200,12 @@ export class RotatingFileStream extends Writable {
 
     try {
       if(this.initPromise) await this.initPromise;
-      if(this.timeoutPromise) await this.timeoutPromise;
 
       for(let i = 0; i < chunks.length; ++i) {
         const { chunk } = chunks[i];
 
         this.size += chunk.length;
+        if(this.timeoutPromise) await this.timeoutPromise;
         await this.file.write(chunk);
 
         if(teeToStdout && ! this.stdout.destroyed) this.stdout.write(chunk);


### PR DESCRIPTION
This fixes the following race condition:

 * task A: rewrite, awaits this.file.write
 * task B: interval set, destroys this.file and sets this.timeoutPromise
 * task A: await finishes and goes on to write the next chunk, but this.file is now destroyed so the app crashes.

Fixes: #84, #95