### PR TITLE
feat: improve generic filename generator function for greater flexibility and extension handling

### DIFF
--- a/test/07compression.test.ts
+++ b/test/07compression.test.ts
@@ -45,6 +45,139 @@ describe("compression", () => {
     it("rotated file content", () => eq(gunzipSync(readFileSync("test1.log")).toString(), "test\ntest\n"));
   });
 
+  describe("custom external with extention", () => {
+    const pad = (num?: number): string =>
+      typeof num === "number" ? (num > 9 ? "" : "0") + num : "";
+
+    describe("when compress is undefined & omitExtension is true", () => {
+      const events = test(
+        {
+          filename: (time: number | Date, index?: number, needsCompressExt?: boolean) => {
+            if(! time) return "test.log";
+              
+            else {
+              const date = new Date(time);
+              const year = date.getFullYear();
+              const month = String(date.getMonth() + 1).padStart(2, '0');
+              const day = String(date.getDate()).padStart(2, '0'); 
+              const hour = String(date.getHours()).padStart(2, '0'); 
+              const minute = String(date.getMinutes()).padStart(2, '0'); 
+              
+              return `${year}${month}${day}-${hour}${minute}-${pad(index)}-test.log${needsCompressExt ? ".gz" : ""}`;
+            }
+          },
+          options: { omitExtension: true, size: "10B" } 
+        },
+        rfs => {
+          rfs.now = (): Date => new Date(2015, 2, 29, 1, 29, 23, 123);
+          rfs.end("test\ntest\n");    
+        }
+      );
+
+      it("events", () => deq(events, { close: 1, finish: 1, open: ["test.log", "test.log"], rotated: ["20150329-0129-01-test.log"], rotation: 1, write: 1 }));
+      it("file content", () => eq(readFileSync("test.log", "utf8"), ""));
+      it("rotated file content", () => eq(readFileSync("20150329-0129-01-test.log", "utf8"), "test\ntest\n"));
+
+    });
+
+    describe("when compress is undefined & omitExtension is false", () => {
+      const events = test(
+        {
+          filename: (time: number | Date, index?: number, needsCompressExt?: boolean) => {
+            if(! time) return "test.log";
+              
+            else {
+              const date = new Date(time);
+              const year = date.getFullYear();
+              const month = String(date.getMonth() + 1).padStart(2, '0');
+              const day = String(date.getDate()).padStart(2, '0'); 
+              const hour = String(date.getHours()).padStart(2, '0'); 
+              const minute = String(date.getMinutes()).padStart(2, '0'); 
+
+              return `${year}${month}${day}-${hour}${minute}-${pad(index)}-test.log${needsCompressExt ? ".gz" : ""}`;
+            }
+          },
+          options: { omitExtension: false, size: "10B" } 
+        },
+        rfs => {
+          rfs.now = (): Date => new Date(2015, 2, 29, 1, 29, 23, 123);
+          rfs.end("test\ntest\n");    
+        }
+      );
+
+      it("events", () => deq(events, { close: 1, finish: 1, open: ["test.log", "test.log"], rotated: ["20150329-0129-01-test.log"], rotation: 1, write: 1 }));
+      it("file content", () => eq(readFileSync("test.log", "utf8"), ""));
+      it("rotated file content", () => eq(readFileSync("20150329-0129-01-test.log", "utf8"), "test\ntest\n"));
+
+      
+    });
+
+    describe("when compress is defined & omitExtension is true", () => {
+      const events = test(
+        {
+          filename: (time: number | Date, index?: number, needsCompressExt?: boolean) => {
+            if(! time) return "test.log";
+              
+            else {
+              const date = new Date(time);
+              const year = date.getFullYear();
+              const month = String(date.getMonth() + 1).padStart(2, '0');
+              const day = String(date.getDate()).padStart(2, '0'); 
+              const hour = String(date.getHours()).padStart(2, '0'); 
+              const minute = String(date.getMinutes()).padStart(2, '0'); 
+              
+              return `${year}${month}${day}-${hour}${minute}-${pad(index)}-test.log${needsCompressExt ? ".gz" : ""}`;
+            }
+          },
+          options: { compress: 'gzip', omitExtension: true, size: "10B" } 
+        },
+        rfs => {
+          rfs.now = (): Date => new Date(2015, 2, 29, 1, 29, 23, 123);
+          rfs.end("test\ntest\n");    
+        }
+      );
+
+      it("events", () => deq(events, { close: 1, finish: 1, open: ["test.log", "test.log"], rotated: ["20150329-0129-01-test.log"], rotation: 1, write: 1 }));
+      it("file content", () => eq(readFileSync("test.log", "utf8"), ""));
+      it("rotated file content", () => eq(gunzipSync(readFileSync("20150329-0129-01-test.log")).toString(), "test\ntest\n"));
+
+
+    });
+
+    describe("when compress is defined & omitExtension is false", () => {
+      const events = test(
+        {
+          filename: (time: number | Date, index?: number, needsCompressExt?: boolean) => {
+            if(! time) return "test.log";
+              
+            else {
+              const date = new Date(time);
+              const year = date.getFullYear();
+              const month = String(date.getMonth() + 1).padStart(2, '0');
+              const day = String(date.getDate()).padStart(2, '0'); 
+              const hour = String(date.getHours()).padStart(2, '0'); 
+              const minute = String(date.getMinutes()).padStart(2, '0'); 
+              
+              return `${year}${month}${day}-${hour}${minute}-${pad(index)}-test.log${needsCompressExt ? ".gz" : ""}`;
+            }
+          },
+          options: { compress: 'gzip', omitExtension: false, size: "10B" } 
+        },
+        rfs => {
+          rfs.now = (): Date => new Date(2015, 2, 29, 1, 29, 23, 123);
+          rfs.end("test\ntest\n");    
+        }
+      );
+
+      it("events", () => deq(events, { close: 1, finish: 1, open: ["test.log", "test.log"], rotated: ["20150329-0129-01-test.log.gz"], rotation: 1, write: 1 }));
+      it("file content", () => eq(readFileSync("test.log", "utf8"), ""));
+      it("rotated file content", () => eq(gunzipSync(readFileSync("20150329-0129-01-test.log.gz")).toString(), "test\ntest\n"));
+
+      
+    });
+
+  });
+
   describe("generator", () => {
     const events = test({ filename: "test.log", options: { compress: "gzip", mode: 0o660, size: "10B" } }, rfs => {
       rfs.now = (): Date => new Date(2015, 2, 29, 1, 29, 23, 123);


### PR DESCRIPTION
This PR addresses the generic filename generator function to help users check and determine the appropriate file extension.

Related to #112

I would like to propose the following improvements based on our previous discussion:

(1) I believe the current approach has some limitations because each time the compress option changes, developers must manually update the filename generator to match the correct file extension. This increases the chance of mistakes and makes maintenance less convenient.

(2) In my opinion, if the compress option were passed to the filename generator, it would allow for more flexible and maintainable code. Developers could adjust the compression setting without having to modify the generator function every time.

(3) I also think that including the compress information in the generator's context would make the API more consistent, since other options like index and time are already provided as context. This would make the usage feel more intuitive and developer-friendly.

```javascript
  // Modified Generator: added needsCompressExt boolean parameter instead of passing the 'compress' variable directly, making it more suitable for the filename generation purpose
 export type Generator = (time: number | Date, index?: number, needsCompressExt?: boolean) => string;
```

Here's how you can use it:

```javascript
const getCurrentLogFileWithDateGenerator = (time, index, needsCompressExt) : string=> {
     if(!time) {
        console.log("Time is undefined. Using default log filename.");
        return DEFAULT_LOG_FILENAME;
     }

      const date = time instanceof Date ? time : new Date(time);
      const year = date.getFullYear();
      const month = String(date.getMonth() + 1).padStart(2, '0');
      const day = String(date.getDate()).padStart(2, '0');
      const hour = String(date.getHours()).padStart(2, '0');
      const minute = String(date.getMinutes()).padStart(2, '0');
      const second = String(date.getSeconds()).padStart(2, '0');

      if(needsCompressExt) {
          return  `${year}-${month}-${day}-${hour}${minute}${second}_${pad(index)}.log.gz`;
      }else {
          return  `${year}-${month}-${day}-${hour}${minute}${second}_${pad(index)}.log`;
      }
}
```